### PR TITLE
Demo changes

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -18,12 +18,17 @@ function App() {
   const [showConfetti, setShowConfetti] = useState(false);
   useEffect(() => {
     const currentUrl = window.location.href;
-    // extract the relevant part of the url
     const urlParts = currentUrl.split('/');
     const baseUrl = urlParts.slice(0, urlParts.length - 1).join('/');
     console.log(baseUrl);
     const newSocket = io(baseUrl);
     setSocket(newSocket);
+    
+    const path = window.location.pathname;
+    if (path === '/pay') {
+      setStep(3);  // Move directly to PaymentConfirmation
+    }
+    
     return () => newSocket.close();
   }, []);
   useEffect(() => {

--- a/client/src/components/PaymentConfirmation.js
+++ b/client/src/components/PaymentConfirmation.js
@@ -11,7 +11,7 @@ function PaymentConfirmation({ adjustedPayments, onPaymentComplete, onBack, sock
     }, [adjustedPayments]);
 
   const handlePay = (name) => {
-    socket.emit('updatePaymentStatus', { name, amount: 0 });
+    socket.emit('updatePaymentStatus', { name, amount: adjustedPayments[name] });
 
   };
 


### PR DESCRIPTION
Solution for: 
```
There are a few changes I would like to do to the demo:
1. when going to /pay route, I want to automatically use the last used adjustment and send directly to the payment confirm step
2. I want to keep the original amount paid instead of switching it to 0

Dont add any new library

That's it, make sure you follow the correct format of prompt.txt

```