### PR TITLE
Changes to first screen 

### DIFF
--- a/client/src/components/PaymentConfirmation.js
+++ b/client/src/components/PaymentConfirmation.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-function PaymentConfirmation({ adjustedPayments, paidStatus, onPaymentComplete, onBack, socket }) {
+function PaymentConfirmation({ adjustedPayments, paidStatus, onPaymentComplete, onBack, socket, selectedPerson }) {
     useEffect(() => {
         const values = Object.values(paidStatus);
         const allPaid =values.length>2 && values.every(status => status === true);
@@ -19,11 +19,11 @@ function PaymentConfirmation({ adjustedPayments, paidStatus, onPaymentComplete, 
     <div className="space-y-6">
       <h2 className="text-2xl font-semibold mb-4">Confirm Your Payment</h2>
       <div className="space-y-4">
-        {Object.entries(adjustedPayments).map(([name, amount]) => (
+        {[selectedPerson].map((name) => (
           <div key={name} className="flex justify-between items-center p-4 bg-gray-100 rounded-lg">
             <p className="text-lg font-medium">{name}</p>
             <div className="flex items-center space-x-4">
-              <span className="text-lg font-semibold">${amount.toFixed(2)}</span>
+              <span className="text-lg font-semibold">${adjustedPayments[name].toFixed(2)}</span>
               {paidStatus[name] ? (
                 <span className="text-green-500 font-medium">Paid</span>
               ) : (
@@ -35,7 +35,13 @@ function PaymentConfirmation({ adjustedPayments, paidStatus, onPaymentComplete, 
                   Pay
                 </button>
               )}
-      </div>
+          <button
+            onClick={() => handlePay(selectedPerson)}
+            className="bg-blue-500 text-white px-6 py-2 rounded-md hover:bg-blue-600 transition-colors"
+          >
+            Share
+          </button>
+        </div>
           </div>
         ))}
       </div>

--- a/client/src/components/SelectionScreen.js
+++ b/client/src/components/SelectionScreen.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+function SelectionScreen({ onPersonSelected }) {
+  const people = [
+    { name: 'Matan Ellhayani', id: 'matan' },
+    { name: 'itamar hay', id: 'itamar' },
+    { name: 'Plony Almony', id: 'plony' }
+  ];
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Select Your Name</h2>
+      <ul className="space-y-2">
+        {people.map((person) => (
+          <li key={person.id} className="bg-gray-100 p-4 rounded-md">
+            <button
+              onClick={() => onPersonSelected(person.name)}
+              className="w-full text-left text-lg hover:text-primary transition-colors"
+            >
+              {person.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default SelectionScreen;


### PR DESCRIPTION
Solution for: 
```
The first screen (now - where you invite) should now function as a selection for who you are, you can click on any one of the options and continue onto a specific paying screen, afterwards you will be at the final screen where you wait for everyone else to pay.
In the final screen is where the invite comes in, but instead it's as a single "share" button.

User story:
> enter the site 
> select my name from the list of paying people 
> go to a pay your share page, and pay
> move to the page where I wait my friends to pay 

Of course add it as a component 

```